### PR TITLE
Add Docker install and compose deployment roles

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -8,3 +8,5 @@
     - role: system_prep
     - role: mounts
     - role: folders
+    - role: docker_engine
+    - role: compose_deploy

--- a/roles/compose_deploy/defaults/main.yml
+++ b/roles/compose_deploy/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+compose_dst: "/home/{{ main_user }}/docker/docker-compose.yml"
+vpn_env_dir: "/home/{{ main_user }}/docker/vpn"
+vpn_env_file: "{{ vpn_env_dir }}/.env"

--- a/roles/compose_deploy/tasks/main.yml
+++ b/roles/compose_deploy/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+# Deploy the media stack using Docker Compose and Gluetun VPN
+
+- name: Ensure docker config root exists
+  file:
+    path: "/home/{{ main_user }}/docker"
+    state: directory
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0775'
+
+- name: Ensure VPN env directory exists
+  file:
+    path: "{{ vpn_env_dir }}"
+    state: directory
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0770'
+
+- name: Render Gluetun env file
+  template:
+    src: gluetun.env.j2
+    dest: "{{ vpn_env_file }}"
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0600'
+
+- name: Render docker-compose.yml
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{ compose_dst }}"
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0644'
+
+- name: Ensure vpn_network exists
+  community.docker.docker_network:
+    name: vpn_network
+    driver: bridge
+
+- name: Bring up stack with Docker Compose
+  community.docker.docker_compose:
+    project_src: "/home/{{ main_user }}/docker"
+    files:
+      - "{{ compose_dst }}"
+    state: present
+  register: compose_result
+
+- name: Check vpn container health
+  community.docker.docker_container_info:
+    name: vpn
+  register: vpn_info
+  retries: 5
+  delay: 15
+  until: vpn_info.containers and vpn_info.containers[0].State.Health.Status == 'healthy'
+
+- name: Assert vpn container is healthy
+  assert:
+    that:
+      - vpn_info.containers | length > 0
+      - vpn_info.containers[0].State.Health.Status == 'healthy'
+    fail_msg: "Gluetun vpn container is not healthy. Check credentials or connectivity."

--- a/roles/compose_deploy/templates/docker-compose.yml.j2
+++ b/roles/compose_deploy/templates/docker-compose.yml.j2
@@ -1,0 +1,264 @@
+version: "3.8"
+services:
+  vpn:
+    image: qmcgaw/gluetun:latest
+    container_name: vpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    volumes:
+      - "/home/{{ main_user }}/docker/vpn:/gluetun"
+    env_file:
+      - {{ vpn_env_file }}
+    healthcheck:
+      test: curl --fail http://localhost:8000 || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+    ports:
+      - 9117:9117
+      - 8989:8989
+      - 7878:7878
+      - 9091:9091
+      - 6789:6789
+      - 6500:6500
+      - 8686:8686
+      - 8080:8080
+    networks:
+      - vpn_network
+
+  requestrr:
+    image: thomst08/requestrr:latest
+    container_name: requestrr
+    network_mode: bridge
+    environment:
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+      - TZ={{ timezone }}
+    volumes:
+      - /home/{{ main_user }}/docker/requestrr/config:/config
+    restart: unless-stopped
+    ports:
+      - 4545:4545
+
+  jackett:
+    image: linuxserver/jackett:latest
+    container_name: jackett
+    network_mode: "service:vpn"
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/jackett:/config
+      - /mnt/downloads:/downloads/completed/
+    restart: unless-stopped
+
+  sonarr:
+    image: linuxserver/sonarr:latest
+    container_name: sonarr
+    network_mode: "service:vpn"
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/sonarr:/config
+      - /mnt/storage/TV:/tv
+      - /mnt/downloads:/downloads
+      - /mnt/downloads/completed/transmission/iplayar:/downloads/iplayar
+    restart: unless-stopped
+
+  radarr:
+    image: linuxserver/radarr:latest
+    container_name: radarr
+    network_mode: "service:vpn"
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/radarr:/config
+      - /mnt/storage/Movies:/movies
+      - /mnt/downloads:/downloads
+    restart: unless-stopped
+
+  lidarr:
+    image: lscr.io/linuxserver/lidarr:latest
+    container_name: lidarr
+    network_mode: "service:vpn"
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/lidarr/config:/config
+      - /mnt/storage/music:/music
+      - /mnt/downloads:/downloads
+    restart: unless-stopped
+
+  transmission:
+    image: linuxserver/transmission:latest
+    container_name: transmission
+    network_mode: "service:vpn"
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/transmission:/config
+      - /mnt/downloads:/downloads
+    restart: unless-stopped
+
+  rdtclient:
+    image: rogerfar/rdtclient
+    container_name: rdtclient
+    network_mode: "service:vpn"
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/rdtclient:/data/db
+      - /mnt/downloads:/downloads
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+    restart: unless-stopped
+
+  sabnzbd:
+    image: lscr.io/linuxserver/sabnzbd:latest
+    container_name: sabnzbd
+    network_mode: "service:vpn"
+    environment:
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+      - TZ={{ timezone }}
+    volumes:
+      - /home/{{ main_user }}/docker/sabnzbd/config:/config
+      - /mnt/downloads/sabdnzbd.incomplete:/incomplete-downloads
+      - /mnt/downloads:/downloads
+    restart: unless-stopped
+
+  get_iplayer:
+    image: ghcr.io/thespad/get_iplayer:latest
+    container_name: get_iplayer
+    network_mode: bridge
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+      - INCLUDERADIO=false
+      - ENABLEIMPORT=true
+    volumes:
+      - /home/{{ main_user }}/docker/get_iplayer/config:/config
+      - /mnt/downloads/getiplayer:/downloads/incomplete
+      - /mnt/downloads/completed/transmission/iplayar:/downloads/iplayar
+    ports:
+      - 1935:1935
+    restart: unless-stopped
+
+  lazylibrarian:
+    image: linuxserver/lazylibrarian:latest
+    container_name: lazylibrarian
+    network_mode: bridge
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/lazylibrarian:/config
+      - /mnt/storage/books:/books
+      - /mnt/storage/audiobooks:/audiobooks
+      - /mnt/downloads/transmission/books:/downloads
+    ports:
+      - 5299:5299
+    restart: unless-stopped
+
+  audiobookshelf:
+    image: ghcr.io/advplyr/audiobookshelf:latest
+    container_name: audiobookshelf
+    network_mode: bridge
+    ports:
+      - 13378:80
+    volumes:
+      - /mnt/storage/audiobooks:/audiobooks
+      - /mnt/storage/podcasts:/podcasts
+      - /home/{{ main_user }}/docker/audiobookshelf/config:/config
+      - /home/{{ main_user }}/docker/audiobookshelf/metadata:/metadata
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+
+  navidrome:
+    image: deluan/navidrome:latest
+    container_name: navidrome
+    network_mode: bridge
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+      - ND_LASTFM_APIKEY=450e8b940228b549b766270f90d67740
+      - ND_LASTFM_SECRET=113f77e069b7e9e5d93f66d3e72aa0a2
+    volumes:
+      - /home/{{ main_user }}/docker/navidrome:/data
+      - /mnt/storage/music:/music:ro
+    ports:
+      - "4533:4533"
+    restart: unless-stopped
+
+  jellyfin:
+    image: linuxserver/jellyfin:latest
+    container_name: jellyfin
+    network_mode: bridge
+    environment:
+      - TZ={{ timezone }}
+      - PUID={{ puid }}
+      - PGID={{ pgid }}
+    volumes:
+      - /home/{{ main_user }}/docker/jellyfin:/config
+      - /mnt/storage/:/media
+    ports:
+      - 8096:8096
+      - 8920:8920
+    restart: unless-stopped
+
+  pi-health-dashboard:
+    image: brownster/pi-health:latest
+    container_name: pi-health-dashboard
+    environment:
+      - TZ={{ timezone }}
+      - DISK_PATH=/mnt/storage
+      - DISK_PATH_2=/mnt/downloads
+      - DOCKER_COMPOSE_PATH=/config/docker-compose.yml
+      - ENV_FILE_PATH=/config/.env
+      - BACKUP_DIR=/config/backups
+    ports:
+      - 8100:8080
+    volumes:
+      - /proc:/host_proc:ro
+      - /sys:/host_sys:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /home/{{ main_user }}/docker/:/config
+      - /mnt/storage:/mnt/storage
+      - /mnt/downloads:/mnt/downloads
+    restart: unless-stopped
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=3600
+      - WATCHTOWER_INCLUDE="vpn,sonarr,radarr,pi-health-dashboard,airsonic-advanced,audiobookshelf,get_iplayer,sabnzbd,rdtclient,transmission,lidarr,navidrome"
+    restart: unless-stopped
+
+networks:
+  vpn_network:
+    driver: bridge

--- a/roles/compose_deploy/templates/gluetun.env.j2
+++ b/roles/compose_deploy/templates/gluetun.env.j2
@@ -1,0 +1,5 @@
+VPN_SERVICE_PROVIDER={{ vpn.provider }}
+OPENVPN_USER={{ vpn.username }}
+OPENVPN_PASSWORD={{ vpn.password }}
+SERVER_REGIONS={{ vpn.regions | default(['Netherlands']) | join(',') }}
+TZ={{ timezone }}

--- a/roles/docker_engine/tasks/main.yml
+++ b/roles/docker_engine/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+# Install Docker Engine and Compose plugin on Debian Bookworm arm64
+
+- name: Install Docker prerequisites
+  apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Ensure keyring directory exists
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add Docker GPG key
+  get_url:
+    url: https://download.docker.com/linux/debian/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+
+- name: Add Docker apt repository
+  apt_repository:
+    repo: >-
+      deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/debian bookworm stable
+    filename: docker
+    state: present
+
+- name: Install Docker Engine and Compose plugin
+  apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Ensure user is in docker group
+  user:
+    name: "{{ main_user }}"
+    groups: docker
+    append: true
+
+- name: Enable and start Docker
+  service:
+    name: docker
+    enabled: true
+    state: started


### PR DESCRIPTION
## Summary
- install Docker Engine and Compose plugin via new `docker_engine` role
- deploy media stack with templated docker-compose and VPN credentials in `compose_deploy`
- update site playbook to run new roles

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1efda3fb48323837bfa9ad886d199