### PR TITLE
Implement mount guards, remote access, and media shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Pi Media Stack Automation
 
 Ansible configuration for preparing Raspberry Pi 5 devices running Debian Bookworm
-for a media stack. The playbooks currently cover system preparation, mounting of
-storage/download drives, and creation of the required folder structure.
+for a media stack. The playbooks now cover system preparation, mounting of
+storage/download drives, creation of the required folder structure, Docker
+deployment, mount guards, optional Tailscale connectivity, Samba shares, and
+app-specific extras.
 
 ## Repository layout
 
@@ -19,6 +21,22 @@ roles/
     tasks/main.yml
   folders/
     tasks/main.yml
+  docker_engine/
+    tasks/main.yml
+  compose_deploy/
+    tasks/main.yml
+  mount_guard/
+    tasks/main.yml
+    handlers/main.yml
+  tailscale/
+    tasks/main.yml
+  samba_shares/
+    defaults/main.yml
+    tasks/main.yml
+    handlers/main.yml
+  app_extras/
+    tasks/main.yml
+    templates/get_iplayer.config.json.j2
 playbooks/
   site.yml
 files/

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -41,3 +41,34 @@ downloads_dirs:
 # Optional hostname configuration
 set_hostname: false
 hostname_value: "pi-media"
+
+# Explicit mapping of mounts and hosted folders
+mount_map:
+  - name: downloads
+    mount_point: "/mnt/downloads"
+    uuid: "{{ downloads_device_uuid }}"
+    fstype: "{{ downloads_fs }}"
+    folders:
+      - path: "/mnt/downloads"
+        ensure: true
+      - path: "/mnt/downloads/getiplayer"
+        ensure: true
+      - path: "/mnt/downloads/completed"
+        ensure: true
+  - name: storage
+    mount_point: "/mnt/storage"
+    uuid: "{{ storage_device_uuid }}"
+    fstype: "{{ storage_fs }}"
+    folders:
+      - path: "/mnt/storage/Movies"
+        ensure: true
+      - path: "/mnt/storage/TVShows"
+        ensure: true
+      - path: "/mnt/storage/music"
+        ensure: true
+      - path: "/mnt/storage/podcasts"
+        ensure: true
+      - path: "/mnt/storage/books"
+        ensure: true
+      - path: "/mnt/storage/audiobooks"
+        ensure: true

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -10,3 +10,7 @@
     - role: folders
     - role: docker_engine
     - role: compose_deploy
+    - role: mount_guard
+    - { role: tailscale, when: tailscale_auth_key is defined }
+    - role: samba_shares
+    - role: app_extras

--- a/roles/app_extras/tasks/main.yml
+++ b/roles/app_extras/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Additional application-specific configuration files
+
+- name: Ensure get_iplayer config directory exists
+  file:
+    path: "/home/{{ main_user }}/docker/get_iplayer/config"
+    state: directory
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0770'
+
+- name: Render get_iplayer config.json
+  template:
+    src: get_iplayer.config.json.j2
+    dest: "/home/{{ main_user }}/docker/get_iplayer/config/config.json"
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0600'
+
+- name: (Optional) Install weekly backup cron
+  cron:
+    name: "Pi media weekly backup"
+    weekday: 0
+    hour: 3
+    minute: 15
+    user: "{{ main_user }}"
+    job: "/home/{{ main_user }}/docker/pi-health/backup.sh >/dev/null 2>&1"
+    state: absent

--- a/roles/app_extras/templates/get_iplayer.config.json.j2
+++ b/roles/app_extras/templates/get_iplayer.config.json.j2
@@ -1,0 +1,11 @@
+{
+  "enableImport": true,
+  "sonarr": {
+    "url": "http://localhost:8989",
+    "apiKey": "CHANGE_ME"
+  },
+  "radarr": {
+    "url": "http://localhost:7878",
+    "apiKey": "CHANGE_ME"
+  }
+}

--- a/roles/mount_guard/handlers/main.yml
+++ b/roles/mount_guard/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: systemd daemon-reload
+  systemd:
+    daemon_reload: true
+
+- name: restart docker
+  service:
+    name: docker
+    state: restarted

--- a/roles/mount_guard/tasks/main.yml
+++ b/roles/mount_guard/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# Ensure Docker waits for storage and downloads mounts before starting
+
+- name: Ensure docker.service drop-in directory exists
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+    mode: '0755'
+
+- name: Configure docker.service mount guards
+  copy:
+    dest: /etc/systemd/system/docker.service.d/10-wait-for-mounts.conf
+    content: |
+      [Unit]
+      # Ensure media mounts exist before docker starts/restores containers
+      RequiresMountsFor={{ storage_mount_point }} {{ downloads_mount_point }}
+      After=remote-fs.target
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - systemd daemon-reload
+    - restart docker

--- a/roles/samba_shares/defaults/main.yml
+++ b/roles/samba_shares/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Default Samba share definitions
+smb_shares:
+  - name: Movies
+    path: "{{ media_root }}/Movies"
+  - name: TVShows
+    path: "{{ media_root }}/TVShows"
+  - name: Downloads
+    path: "{{ downloads_root }}"

--- a/roles/samba_shares/handlers/main.yml
+++ b/roles/samba_shares/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart smbd
+  service:
+    name: smbd
+    state: restarted

--- a/roles/samba_shares/tasks/main.yml
+++ b/roles/samba_shares/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Install Samba and configure shares
+
+- name: Install Samba packages
+  apt:
+    name:
+      - samba
+      - samba-common-bin
+    state: present
+    update_cache: true
+
+- name: Add Samba shares
+  blockinfile:
+    path: /etc/samba/smb.conf
+    marker: "# {mark} ANSIBLE PI-MEDIA SHARES"
+    block: |
+      {% for s in smb_shares %}
+      [{{ s.name }}]
+      path = {{ s.path }}
+      browseable = yes
+      read only = no
+      guest ok = yes
+      create mask = 0664
+      directory mask = 0775
+
+      {% endfor %}
+  notify: restart smbd
+
+- name: Ensure smbd running and enabled
+  service:
+    name: smbd
+    state: started
+    enabled: true

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# Install and configure Tailscale
+
+- name: Install prerequisites
+  apt:
+    name:
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+
+- name: Add Tailscale apt repo GPG key
+  get_url:
+    url: https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg
+    dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    mode: '0644'
+
+- name: Add Tailscale apt repository
+  apt_repository:
+    repo: >-
+      deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg]
+      https://pkgs.tailscale.com/stable/debian bookworm main
+    filename: tailscale
+    state: present
+
+- name: Install tailscale
+  apt:
+    name: tailscale
+    state: present
+    update_cache: true
+
+- name: Check tailscale status
+  command: tailscale status --peers
+  register: ts_status
+  changed_when: false
+  failed_when: false
+
+- name: Bring up tailscale if not connected
+  command: >-
+    tailscale up --auth-key={{ tailscale_auth_key }} {{ tailscale_extra_args | default('') }}
+  when: ts_status.rc != 0


### PR DESCRIPTION
## Summary
- Ensure Docker waits for media drives using a systemd drop-in
- Optional Tailscale role installs and connects the node
- Add Samba shares and app extras such as get_iplayer config

## Testing
- `ansible-lint` *(command not found)*
- `ansible-playbook -i inventory/hosts.yml playbooks/site.yml --syntax-check` *(command not found)*
- `apt-get update` *(403 Forbidden for archive.ubuntu.com)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f26a3a2c8323b1829cdada61304c