### PR TITLE
Add backup, monitoring and watchtower roles

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -72,3 +72,20 @@ mount_map:
         ensure: true
       - path: "/mnt/storage/audiobooks"
         ensure: true
+
+# Backups
+backups_device_uuid: "UUID-OF-BACKUPS-DRIVE"
+backups_mount_point: "/mnt/backups"
+backups_fs: auto
+backup_keep_daily: 7
+backup_keep_weekly: 4
+backup_mirror_dir: "/home/{{ main_user }}/docker/backups"
+backup_healthcheck_url: ""
+backup_timer_on_calendar: "daily"
+
+# Watchtower
+watchtower_schedule: "0 4 * * *"
+# watchtower_notification_url: ""
+
+# Monitoring
+cadvisor_port: 8082

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -7,10 +7,15 @@
   roles:
     - role: system_prep
     - role: mounts
+    - role: backup_mount
     - role: folders
     - role: docker_engine
+    - role: watchtower_policy
     - role: compose_deploy
     - role: mount_guard
     - { role: tailscale, when: tailscale_auth_key is defined }
     - role: samba_shares
     - role: app_extras
+    - role: backups
+    - role: monitoring
+    - role: webui_integration

--- a/roles/backup_mount/tasks/main.yml
+++ b/roles/backup_mount/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Configure backups mount via fstab and ensure it is mounted
+
+- name: Compute mount options for backups based on FS
+  set_fact:
+    backups_mount_opts: >-
+      {{ mount_opts_ntfs if backups_fs == 'ntfs-3g' else mount_opts_ext4 }}
+
+- name: Ensure backups mount point exists
+  file:
+    path: "{{ backups_mount_point }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure backups drive is in fstab and mounted
+  mount:
+    src: "UUID={{ backups_device_uuid }}"
+    path: "{{ backups_mount_point }}"
+    fstype: "{{ backups_fs }}"
+    opts: "{{ backups_mount_opts }}"
+    state: mounted
+
+- name: Stat backups mount
+  stat:
+    path: "{{ backups_mount_point }}"
+  register: backups_stat
+
+- name: Fail if backups not mounted
+  fail:
+    msg: "Backups mount {{ backups_mount_point }} not available"
+  when: not backups_stat.stat.exists

--- a/roles/backups/tasks/main.yml
+++ b/roles/backups/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+# Install backup script and systemd timer
+
+- name: Install Docker backup script
+  template:
+    src: backup_docker.sh.j2
+    dest: /usr/local/bin/backup_docker.sh
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Install docker-backup.service
+  template:
+    src: docker-backup.service.j2
+    dest: /etc/systemd/system/docker-backup.service
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Install docker-backup.timer
+  template:
+    src: docker-backup.timer.j2
+    dest: /etc/systemd/system/docker-backup.timer
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Reload systemd for backup units
+  systemd:
+    daemon_reload: true
+
+- name: Enable and start docker-backup timer
+  systemd:
+    name: docker-backup.timer
+    state: started
+    enabled: true

--- a/roles/backups/templates/backup_docker.sh.j2
+++ b/roles/backups/templates/backup_docker.sh.j2
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+BACKUP_ROOT="{{ backups_mount_point }}"
+MIRROR_DIR="{{ backup_mirror_dir }}"
+HOSTNAME="$(hostname)"
+DATE="$(date +%Y%m%d)"
+DEST="$BACKUP_ROOT/$HOSTNAME/$DATE"
+MANIFEST_DIR="$DEST/manifest"
+CONFIG_SRC="/home/{{ main_user }}/docker"
+HEALTHCHECK_URL="{{ backup_healthcheck_url }}"
+KEEP_DAILY={{ backup_keep_daily }}
+KEEP_WEEKLY={{ backup_keep_weekly }}
+SERVICES_FILE="/home/{{ main_user }}/services_urls.txt"
+
+mkdir -p "$MANIFEST_DIR"
+
+# Copy docker configs excluding backups directory
+rsync -a --delete --exclude 'backups' "$CONFIG_SRC/" "$DEST/config"
+
+# Generate manifests
+mkdir -p "$MANIFEST_DIR"
+docker ps --format '{{ json . }}' > "$MANIFEST_DIR/containers.json"
+docker images --format '{{.Repository}}:{{.Tag}} {{.ID}}' > "$MANIFEST_DIR/images.txt"
+docker volume ls --quiet | xargs -r docker inspect > "$MANIFEST_DIR/volumes.json"
+
+# Mirror latest backup for web UI
+rm -rf "$MIRROR_DIR"
+mkdir -p "$(dirname "$MIRROR_DIR")"
+cp -a "$DEST" "$MIRROR_DIR"
+chown -R {{ main_user }}:{{ main_group }} "$MIRROR_DIR"
+
+# Backup status for web UI
+printf '{ "last_backup": "%s", "path": "%s" }\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$DEST" > "$MIRROR_DIR/backup_status.json"
+
+# Convert services_urls.txt if present
+if [ -f "$SERVICES_FILE" ]; then
+  python3 <<'PY'
+import json, os
+src = os.environ['SERVICES_FILE']
+dst = os.path.join(os.environ['MIRROR_DIR'], 'services.json')
+data = {}
+with open(src) as f:
+    for line in f:
+        line=line.strip()
+        if not line:
+            continue
+        parts=line.split(None,1)
+        if len(parts)==2:
+            data[parts[0]] = parts[1]
+with open(dst,'w') as out:
+    json.dump(data,out)
+PY
+fi
+
+# Retention logic
+HOST_BACKUP_ROOT="$BACKUP_ROOT/$HOSTNAME"
+KEEP_DAILY="$KEEP_DAILY"
+KEEP_WEEKLY="$KEEP_WEEKLY"
+python3 <<'PY'
+import os, datetime, shutil, collections
+root = os.environ['HOST_BACKUP_ROOT']
+dirs = [d for d in os.listdir(root) if d.isdigit()]
+dirs.sort(reverse=True)
+keep_daily = int(os.environ['KEEP_DAILY'])
+keep_weekly = int(os.environ['KEEP_WEEKLY'])
+daily_keep = set(dirs[:keep_daily])
+weeks = collections.OrderedDict()
+for d in dirs:
+    dt = datetime.datetime.strptime(d, '%Y%m%d')
+    week_key = dt.strftime('%Y-%W')
+    if week_key not in weeks:
+        weeks[week_key] = d
+weekly_keep = set(list(weeks.values())[keep_daily:keep_daily+keep_weekly])
+keep = daily_keep | weekly_keep
+for d in dirs:
+    if d not in keep:
+        shutil.rmtree(os.path.join(root, d))
+PY
+
+# Optional healthcheck ping
+if [ -n "$HEALTHCHECK_URL" ]; then
+  curl -fsS "$HEALTHCHECK_URL" >/dev/null || true
+fi

--- a/roles/backups/templates/docker-backup.service.j2
+++ b/roles/backups/templates/docker-backup.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Backup Docker configuration and manifests
+Wants=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/backup_docker.sh

--- a/roles/backups/templates/docker-backup.timer.j2
+++ b/roles/backups/templates/docker-backup.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Docker backup script
+
+[Timer]
+OnCalendar={{ backup_timer_on_calendar }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/compose_deploy/templates/docker-compose.yml.j2
+++ b/roles/compose_deploy/templates/docker-compose.yml.j2
@@ -1,6 +1,10 @@
 version: "3.8"
+x-watchtower: &watchtower
+  labels:
+    - "com.centurylinklabs.watchtower.enable=true"
 services:
   vpn:
+    <<: *watchtower
     image: qmcgaw/gluetun:latest
     container_name: vpn
     cap_add:
@@ -30,6 +34,7 @@ services:
       - vpn_network
 
   requestrr:
+    <<: *watchtower
     image: thomst08/requestrr:latest
     container_name: requestrr
     network_mode: bridge
@@ -44,6 +49,7 @@ services:
       - 4545:4545
 
   jackett:
+    <<: *watchtower
     image: linuxserver/jackett:latest
     container_name: jackett
     network_mode: "service:vpn"
@@ -57,6 +63,7 @@ services:
     restart: unless-stopped
 
   sonarr:
+    <<: *watchtower
     image: linuxserver/sonarr:latest
     container_name: sonarr
     network_mode: "service:vpn"
@@ -72,6 +79,7 @@ services:
     restart: unless-stopped
 
   radarr:
+    <<: *watchtower
     image: linuxserver/radarr:latest
     container_name: radarr
     network_mode: "service:vpn"
@@ -86,6 +94,7 @@ services:
     restart: unless-stopped
 
   lidarr:
+    <<: *watchtower
     image: lscr.io/linuxserver/lidarr:latest
     container_name: lidarr
     network_mode: "service:vpn"
@@ -100,6 +109,7 @@ services:
     restart: unless-stopped
 
   transmission:
+    <<: *watchtower
     image: linuxserver/transmission:latest
     container_name: transmission
     network_mode: "service:vpn"
@@ -113,6 +123,7 @@ services:
     restart: unless-stopped
 
   rdtclient:
+    <<: *watchtower
     image: rogerfar/rdtclient
     container_name: rdtclient
     network_mode: "service:vpn"
@@ -130,6 +141,7 @@ services:
     restart: unless-stopped
 
   sabnzbd:
+    <<: *watchtower
     image: lscr.io/linuxserver/sabnzbd:latest
     container_name: sabnzbd
     network_mode: "service:vpn"
@@ -144,6 +156,7 @@ services:
     restart: unless-stopped
 
   get_iplayer:
+    <<: *watchtower
     image: ghcr.io/thespad/get_iplayer:latest
     container_name: get_iplayer
     network_mode: bridge
@@ -162,6 +175,7 @@ services:
     restart: unless-stopped
 
   lazylibrarian:
+    <<: *watchtower
     image: linuxserver/lazylibrarian:latest
     container_name: lazylibrarian
     network_mode: bridge
@@ -179,6 +193,7 @@ services:
     restart: unless-stopped
 
   audiobookshelf:
+    <<: *watchtower
     image: ghcr.io/advplyr/audiobookshelf:latest
     container_name: audiobookshelf
     network_mode: bridge
@@ -195,6 +210,7 @@ services:
       - PGID={{ pgid }}
 
   navidrome:
+    <<: *watchtower
     image: deluan/navidrome:latest
     container_name: navidrome
     network_mode: bridge
@@ -212,6 +228,7 @@ services:
     restart: unless-stopped
 
   jellyfin:
+    <<: *watchtower
     image: linuxserver/jellyfin:latest
     container_name: jellyfin
     network_mode: bridge
@@ -228,6 +245,7 @@ services:
     restart: unless-stopped
 
   pi-health-dashboard:
+    <<: *watchtower
     image: brownster/pi-health:latest
     container_name: pi-health-dashboard
     environment:
@@ -253,10 +271,8 @@ services:
     container_name: watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_POLL_INTERVAL=3600
-      - WATCHTOWER_INCLUDE="vpn,sonarr,radarr,pi-health-dashboard,airsonic-advanced,audiobookshelf,get_iplayer,sabnzbd,rdtclient,transmission,lidarr,navidrome"
+    env_file:
+      - /home/{{ main_user }}/docker/watchtower/watchtower.env
     restart: unless-stopped
 
 networks:

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Deploy node_exporter and cAdvisor for monitoring
+
+- name: Install node_exporter package
+  apt:
+    name: prometheus-node-exporter
+    state: present
+    update_cache: true
+
+- name: Ensure node_exporter service is running
+  systemd:
+    name: prometheus-node-exporter
+    state: started
+    enabled: true
+
+- name: Run cAdvisor container
+  community.docker.docker_container:
+    name: cadvisor
+    image: gcr.io/cadvisor/cadvisor:latest
+    state: started
+    restart_policy: unless-stopped
+    published_ports:
+      - "{{ cadvisor_port }}:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro

--- a/roles/mount_guard/tasks/main.yml
+++ b/roles/mount_guard/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Ensure Docker waits for storage and downloads mounts before starting
+# Ensure Docker waits for storage, downloads and backups mounts before starting
 
 - name: Ensure docker.service drop-in directory exists
   file:
@@ -13,7 +13,7 @@
     content: |
       [Unit]
       # Ensure media mounts exist before docker starts/restores containers
-      RequiresMountsFor={{ storage_mount_point }} {{ downloads_mount_point }}
+      RequiresMountsFor={{ storage_mount_point }} {{ downloads_mount_point }}{% if backups_mount_point is defined %} {{ backups_mount_point }}{% endif %}
       After=remote-fs.target
     owner: root
     group: root

--- a/roles/watchtower_policy/tasks/main.yml
+++ b/roles/watchtower_policy/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Configure Watchtower update policy
+
+- name: Ensure watchtower config directory exists
+  file:
+    path: "/home/{{ main_user }}/docker/watchtower"
+    state: directory
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0755'
+
+- name: Render watchtower env file
+  template:
+    src: watchtower.env.j2
+    dest: "/home/{{ main_user }}/docker/watchtower/watchtower.env"
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0644'

--- a/roles/watchtower_policy/templates/watchtower.env.j2
+++ b/roles/watchtower_policy/templates/watchtower.env.j2
@@ -1,0 +1,7 @@
+WATCHTOWER_CLEANUP=true
+WATCHTOWER_LABEL_ENABLE=true
+WATCHTOWER_SCHEDULE={{ watchtower_schedule }}
+{% if watchtower_notification_url is defined and watchtower_notification_url|length > 0 %}
+WATCHTOWER_NOTIFICATIONS=shoutrrr
+WATCHTOWER_NOTIFICATION_URL={{ watchtower_notification_url }}
+{% endif %}

--- a/roles/webui_integration/tasks/main.yml
+++ b/roles/webui_integration/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Prepare backup artifacts for the web UI
+
+- name: Ensure backup mirror directory exists
+  file:
+    path: "{{ backup_mirror_dir }}"
+    state: directory
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0755'
+
+- name: Ensure placeholder backup_status.json exists
+  copy:
+    dest: "{{ backup_mirror_dir }}/backup_status.json"
+    content: '{"last_backup": null}'
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0644'
+    force: no
+
+- name: Ensure placeholder services.json exists
+  copy:
+    dest: "{{ backup_mirror_dir }}/services.json"
+    content: '{}'
+    owner: "{{ main_user }}"
+    group: "{{ main_group }}"
+    mode: '0644'
+    force: no


### PR DESCRIPTION
## Summary
- mount USB backup drive and ensure Docker waits for it
- add daily Docker backup script with retention and web UI artifacts
- configure Watchtower with label-based policy and scheduled updates
- expose node_exporter and cAdvisor metrics
- prepare backup data for pi-health dashboard

## Testing
- `ansible-playbook -i inventory/hosts.yml playbooks/site.yml --syntax-check` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1f4f6c5e08323935de26016ca3dba