### PR TITLE
Use dedicated Vagrant inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ The Docker images and ports for all services are defined as variables in `invent
 
 2.  **Configure your inventory:**
 
-    *   Edit `inventory/hosts.yml` to add the IP address or hostname of your Raspberry Pi.
+    *   For physical Raspberry Pis, edit `inventory/hosts.yml` to add the device's IP address or hostname.
+    *   For local Vagrant testing, `inventory/vagrant.yml` already defines a `default` host for the VM.
     *   Edit `inventory/group_vars/all.yml` to customize the configuration.
     *   Create and encrypt `inventory/group_vars/vault.yml` to store your secrets.
 
 3.  **Run the playbook:**
+
+    To deploy to a physical Raspberry Pi:
 
     ```bash
     ansible-playbook -i inventory/hosts.yml playbooks/site.yml --ask-become-pass
@@ -81,9 +84,13 @@ The Docker images and ports for all services are defined as variables in `invent
     ansible-playbook -i inventory/hosts.yml playbooks/site.yml --ask-become-pass --ask-vault-pass
     ```
 
+    The Vagrant setup uses `inventory/vagrant.yml` automatically when you run `vagrant up` or `vagrant provision`.
+
 ## Local Testing with Vagrant
 
 Instead of testing on a physical Raspberry Pi, you can use Vagrant to create a local virtual machine that mimics your Pi's environment. This is a much faster and more convenient way to test your Ansible playbook.
+
+The provided `Vagrantfile` points to `inventory/vagrant.yml`, which contains a `default` host definition for the virtual machine.
 
 ### Requirements
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbooks/site.yml"
-    ansible.inventory_path = "inventory/hosts.yml"
+    ansible.inventory_path = "inventory/vagrant.yml"
     ansible.extra_vars = {
       # Add any extra variables you need for testing here
       # For example, you might want to disable certain tasks

--- a/inventory/vagrant.yml
+++ b/inventory/vagrant.yml
@@ -1,0 +1,7 @@
+all:
+  hosts:
+    default:
+      ansible_host: 127.0.0.1
+      ansible_port: 2222
+      ansible_user: vagrant
+      ansible_ssh_private_key_file: .vagrant/machines/default/virtualbox/private_key


### PR DESCRIPTION
## Summary
- Create `inventory/vagrant.yml` for the Vagrant VM
- Point Vagrantfile Ansible provisioner to the new inventory
- Clarify in README which inventory to use for Vagrant vs. physical Pis

## Testing
- `ansible-playbook --version` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed / 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a2073d43908323b7f914618d1e8312