### PR TITLE
Map Docker repo architecture from ansible_architecture

### DIFF
--- a/roles/docker_engine/tasks/main.yml
+++ b/roles/docker_engine/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
-# Install Docker Engine and Compose plugin on Debian Bookworm arm64
+# Install Docker Engine and Compose plugin on Debian Bookworm
+
+- name: Determine Docker architecture
+  set_fact:
+    docker_arch: "{{ arch_map.get(ansible_architecture, ansible_architecture) }}"
+  vars:
+    arch_map:
+      aarch64: arm64
+      x86_64: amd64
 
 - name: Install Docker prerequisites
   apt:
@@ -32,7 +40,7 @@
 - name: Add Docker apt repository
   apt_repository:
     repo: >-
-      deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc]
+      deb [arch={{ docker_arch }} signed-by=/etc/apt/keyrings/docker.asc]
       https://download.docker.com/linux/debian bookworm stable
     filename: docker
     state: present


### PR DESCRIPTION
## Summary
- derive Docker repository architecture from `ansible_architecture`
- use mapped architecture in Docker apt repository declaration

## Testing
- `ansible-playbook -i inventory/hosts.yml playbooks/site.yml --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors, cannot install ansible)*

------
https://chatgpt.com/codex/tasks/task_e_68a2093c7e108323963c1295fe4fc786